### PR TITLE
Have npm install phantomjs locally as a dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ allows this library to be used with the <a href="https://github.com/caolan/async
 Installation
 ---------------------------------------------
 - Obviously you need to install <a href="http://nodejs.org">Node.js</a> to use this.
-- Next, you will need to install <a href="http://phantomjs.org">Phantom.js</a>.
 - You can now use this library using the NPM package <strong>jquerygo</strong>
 
 ```

--- a/lib/jquery.go.js
+++ b/lib/jquery.go.js
@@ -1,4 +1,5 @@
 // Include the libraries.
+var phantomjs = require('phantomjs')
 var phantom =   require('node-phantom');
 var async = require('async');
 var _ = require('underscore');
@@ -35,7 +36,7 @@ phantom.create(function(err, ph) {
       queue(page);
     });
   });
-});
+}, { phantomPath: phantomjs.path });
 
 /**
  * Initialize the page.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "node-phantom": ">=0",
     "underscore": ">=0",
     "async": ">=0",
-    "asyncgo": ">=0"
+    "asyncgo": ">=0",
+    "phantomjs": "~1.9.1-9"
   }
 }


### PR DESCRIPTION
I noticed that you are requiring the user to install phantom independently, which is just an additional obstacle and makes deployment to servers more difficult, but I knew that the test runner I use automatically installs phantom through npm, so I brought that in here. Now a simple "npm install" should be all that's necessary to get up and running.

Originally I was motivated by wanting to contribute to [makemeasandwhich](https://npmjs.org/package/makemeasandwich) but this will have to do :)

Nice library btw. Super simple to use.
