### PR TITLE
Ported the 'uploadFile' method in PhantomJS API to jquery.go.js

### DIFF
--- a/lib/jquery.go.js
+++ b/lib/jquery.go.js
@@ -359,6 +359,15 @@ var jQuery = _.extend(function(selector, context) {
   },
 
   /**
+   * Upload File to a Form.
+   */
+  uploadFile: function(selector, filename, done) {
+    getPage(function(page) {
+      page.uploadFile(selector, filename, done);
+    });
+  },
+
+  /**
    * Close the phantom browser.
    * @returns {undefined}
    */


### PR DESCRIPTION
Usage: uploadFile(selector, filepath)

E.G. $.uploadFile('input[id=uploadForm_file]', __dirname + '/pic.jpg');
