### PR TITLE
Page loading extensions.

### DIFF
--- a/lib/jquery.go.js
+++ b/lib/jquery.go.js
@@ -26,6 +26,9 @@ phantom.create("--web-security=no", "--ignore-ssl-errors=yes", function(ph) {
     // Num resources outstanding.
     var resources = 0;
 
+    // Whether page has loaded.
+    var ready = false;
+
     // Pass along console messages.
     page.set('onConsoleMessage', function(msg) {
       console.log('Console:' + msg);
@@ -33,13 +36,15 @@ phantom.create("--web-security=no", "--ignore-ssl-errors=yes", function(ph) {
 
     // Increment our outstanding resources counter.
     page.set('onResourceRequested', function() {
-      loading = true;
-      resources++;
+      if (ready) {
+        loading = true;
+        resources++;
+      }
     });
 
     // Fire an event when we have received a resource.
     page.set('onResourceReceived', function(res) {
-      if ((res.stage == 'end') && (--resources == 0)) {
+      if (ready && (res.stage == 'end') && (--resources == 0)) {
         loading = false;
       }
     });
@@ -52,6 +57,7 @@ phantom.create("--web-security=no", "--ignore-ssl-errors=yes", function(ph) {
     // Trigger when the loading has finished.
     page.set('onLoadFinished', function() {
       loading = (resources > 0);
+      ready = true;
     });
 
     // Empty the get page queue.
@@ -195,7 +201,16 @@ jQueryInterface.prototype.asyncCall = function() {
   });
   var method = args.shift();
   var callback = args.pop();
-  this.asyncExecute(method, args, callback);
+  context = function(val) {
+    if (loading) {
+      setTimeout(function() {
+        context(val);
+      }, 100);
+    } else {
+      callback(val);
+    }
+  }
+  this.asyncExecute(method, args, context);
 };
 
 // Set the go method.


### PR DESCRIPTION
Great DSL for Phantom.js really helped with refactoring a Node.js scraper I'm working on.

For a Javascript heavy site I was looking to interact with the UI, I noticed the page would hang forever. I found there to be a discrepancy in the resource counter when onLoadFinished was fired. So I've added a flag to only wait for AJAX resources after the page is ready.

In addition I used the loading status to automatically wait for AJAX to load after mouse click when the page is being interacted with.

This is my first pull request btw :ghost: 
