### PR TITLE
use https for the jQuery path

### DIFF
--- a/lib/jquery.go.js
+++ b/lib/jquery.go.js
@@ -311,7 +311,7 @@ var jQuery = _.extend(function(selector, context) {
    */
   config: {
     addJQuery: true,
-    jQuery: '//code.jquery.com/jquery-1.11.1.min.js',
+    jQuery: 'https://code.jquery.com/jquery-1.11.1.min.js',
     site: '',
     width: 1920,
     height: 1080,


### PR DESCRIPTION
Like #23, but using `https` instead of `http`. I have three reasons to do this:
- `https://code.jquery.com/jquery-1.11.1.min.js` works fine with `https`
- `//example.com/script.js` is a little bit slower than `https://example.com/script.js`  (I did read a blog post about that, but cannot find it right now.) But it's obvious, the browser should resolve them using the current protocol.
- `//example.com/script.js` will give a nasty error when `$.visit`ing local HTML files.

@travist I found this nice library after watching your talk about it. Niiiice stuff! :clap: :tada: 
